### PR TITLE
nginx-proxy -> https-portal

### DIFF
--- a/pillar/https-portal.sls
+++ b/pillar/https-portal.sls
@@ -1,4 +1,4 @@
 https-portal:
   stage: local
   domains:
-    example.com: http://example:8080
+    - 'example.com -> http://example:8080'

--- a/pillar/https-portal.sls
+++ b/pillar/https-portal.sls
@@ -1,0 +1,4 @@
+https-portal:
+  stage: local
+  domains:
+    example.com: http://example:8080

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -21,7 +21,7 @@
   'eligundry_device:server':
     - match: grain
     - server
-    - https_portal
+    - https-portal
     - website
     - openvpn
     - znc

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -21,6 +21,7 @@
   'eligundry_device:server':
     - match: grain
     - server
+    - https_portal
     - website
     - openvpn
     - znc

--- a/salt/server/https-portal/init.sls
+++ b/salt/server/https-portal/init.sls
@@ -8,6 +8,7 @@ nginx-proxy-stopped:
     - names:
       - nginx-proxy
       - letsencrypt
+    - force: True
 
 {{ https_portal_dir }}:
   file.directory:

--- a/salt/server/https-portal/init.sls
+++ b/salt/server/https-portal/init.sls
@@ -30,7 +30,7 @@ https-portal:
     - image: {{ https_portal_image }}
     - environment:
       - STAGE: {{ data['stage'] }}
-      - DOMAINS: {{ ', '.join([(domain + ' -> ' + internal) for domain, internal in data['domains'].items()]) }}
+      - DOMAINS: {{ ', '.join(data['domains']) }}
     - port_bindings:
       - "80:80"
       - "443:443"

--- a/salt/server/https-portal/init.sls
+++ b/salt/server/https-portal/init.sls
@@ -30,7 +30,7 @@ https-portal:
     - image: {{ https_portal_image }}
     - environment:
       - STAGE: {{ data['stage'] }}
-      - DOMAINS: {{ ', '.join((domain + ' -> ' + internal) for domain, internal in data['domains'].items()) }}
+      - DOMAINS: {{ ', '.join([(domain + ' -> ' + internal) for domain, internal in data['domains'].items()]) }}
     - port_bindings:
       - "80:80"
       - "443:443"

--- a/salt/server/https-portal/init.sls
+++ b/salt/server/https-portal/init.sls
@@ -40,7 +40,7 @@ https-portal:
       - "80:80"
       - "443:443"
     - network:
-      - https-portal-network
+      - https-portal-network:
         - aliases:
           - https-portal
     - binds:

--- a/salt/server/https-portal/init.sls
+++ b/salt/server/https-portal/init.sls
@@ -39,7 +39,7 @@ https-portal:
     - port_bindings:
       - "80:80"
       - "443:443"
-    - network:
+    - networks:
       - https-portal-network:
         - aliases:
           - https-portal

--- a/salt/server/https-portal/init.sls
+++ b/salt/server/https-portal/init.sls
@@ -26,6 +26,10 @@ nginx-proxy-stopped:
   docker_image.present:
     - force: {{ pull_latest }}
 
+https-portal-network:
+  docker_network.present:
+    - driver: bridge
+
 https-portal:
   docker_container.running:
     - image: {{ https_portal_image }}
@@ -35,8 +39,13 @@ https-portal:
     - port_bindings:
       - "80:80"
       - "443:443"
+    - network:
+      - https-portal-network
+        - aliases:
+          - https-portal
     - binds:
       - {{ https_portal_dir }}:/var/lib/https-portal
     - restart_policy: always
     - require:
       - {{ https_portal_image }}
+      - https-portal-network

--- a/salt/server/https-portal/init.sls
+++ b/salt/server/https-portal/init.sls
@@ -1,0 +1,41 @@
+{% set https_portal_image = 'steveltn/https-portal' %}
+{% set https_portal_dir = '/opt/https-portal' %}
+{% set data = pillar['https-portal'] %}
+{% set pull_latest = pillar['docker_pull_latest'] %}
+
+nginx-proxy-stopped:
+  docker_container.absent:
+    - names:
+      - nginx-proxy
+      - letsencrypt
+
+{{ https_portal_dir }}:
+  file.directory:
+    - user: docker
+    - group: docker
+    - dir_mode: 755
+    - file_mode: 660
+    - makedirs: True
+    - recurse:
+      - user
+      - group
+      - mode
+
+{{ https_portal_image }}:
+  docker_image.present:
+    - force: {{ pull_latest }}
+
+https-portal:
+  docker_container.running:
+    - image: {{ https_portal_image }}
+    - environment:
+      - STAGE: {{ data['stage'] }}
+      - DOMAINS: {{ ', '.join((domain + ' -> ' + internal) for domain, internal in data['domains'].items()) }}
+    - port_bindings:
+      - "80:80"
+      - "443:443"
+    - binds:
+      - {{ https_portal_dir }}:/var/lib/https-portal
+    - restart_policy: always
+    - require:
+      - {{ https_portal_image }}

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -3,6 +3,9 @@ include:
   - server.salt-master
   - server.salt-cloud
   - server.salt-master
+  # Swapped to https-portal from the nginx-proxy
+  - server.https-portal
+  # - server.nginx-proxy
   - server.website
   # Disable Gitlab for the time being
   # - server.gitlab

--- a/salt/server/nginx-proxy.sls
+++ b/salt/server/nginx-proxy.sls
@@ -8,6 +8,7 @@ https-portal-stopped:
   docker_container.absent:
     - names:
       - https-portal
+    - force: True
 
 {{ letsencrypt_dir }}:
   file.directory:

--- a/salt/server/nginx-proxy.sls
+++ b/salt/server/nginx-proxy.sls
@@ -1,0 +1,71 @@
+{% set letsencrypt_dir = '/opt/letsencrypt' %}
+{% set pull_latest = pillar['docker_pull_latest'] %}
+{% set nginx_image = 'jwilder/nginx-proxy:alpine' %}
+{% set letsencrypt = pillar['letsencrypt'] %}
+{% set letsencrypt_image = 'jrcs/letsencrypt-nginx-proxy-companion:latest' %}
+
+https-portal-stopped:
+  docker_container.absent:
+    - names:
+      - https-portal
+
+{{ letsencrypt_dir }}:
+  file.directory:
+    - user: docker
+    - group: docker
+    - dir_mode: 775
+    - file_mode: 660
+    - makedirs: True
+    - recurse:
+      - user
+      - group
+      - mode
+
+{{ nginx_image }}:
+  docker_image.present:
+    - force: {{ pull_latest }}
+
+nginx-proxy:
+  docker_container.running:
+    - image: {{ nginx_image }}
+    - volumes:
+      - /etc/nginx/conf.d
+      - /etc/nginx/vhost.d
+      - /usr/share/nginx/html
+    - binds:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - {{ letsencrypt_dir }}:/etc/nginx/certs:ro
+    - port_bindings:
+      - "80:80"
+      - "443:443"
+    - restart_policy: always
+    - require:
+      - {{ nginx_image }}
+      - {{ letsencrypt_dir }}
+
+# This is disabled in Vagrant because it will fail to validate certs and make
+# the dev website impossible to reach because certs and will force SSL on the
+# Nginx reverse proxy.
+{% if salt['grains.get']('virtual') != 'VirtualBox' %}
+
+{{ letsencrypt_image }}:
+  docker_image.present:
+    - force: {{ pull_latest }}
+
+letsencrypt:
+  docker_container.running:
+    - image: {{ letsencrypt_image }}
+    - volumes_from:
+      - nginx-proxy
+    - binds:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - {{ letsencrypt_dir }}:/etc/nginx/certs:rw
+    - restart_policy: always
+    - environment:
+      - ACME_TOS_HASH=cc88d8d9517f490191401e7b54e9ffd12a2b9082ec7a1d4cec6101f9f1647e7b
+    - require:
+      - {{ letsencrypt_dir }}
+      - {{ letsencrypt_image }}
+      - nginx-proxy
+
+{% endif %}

--- a/salt/server/pi-hole.sls
+++ b/salt/server/pi-hole.sls
@@ -47,7 +47,7 @@ pi-hole:
       - WEBPASSWORD: "{{ pillar['pi-hole']['password'] }}"
     - restart_policy: always
     - network:
-      - https-portal-network
+      - https-portal-network:
         - aliases:
           - pi-hole
     - binds:

--- a/salt/server/pi-hole.sls
+++ b/salt/server/pi-hole.sls
@@ -46,7 +46,7 @@ pi-hole:
       - VIRTUAL_PORT: '80'
       - WEBPASSWORD: "{{ pillar['pi-hole']['password'] }}"
     - restart_policy: always
-    - network:
+    - networks:
       - https-portal-network:
         - aliases:
           - pi-hole

--- a/salt/server/pi-hole.sls
+++ b/salt/server/pi-hole.sls
@@ -46,6 +46,10 @@ pi-hole:
       - VIRTUAL_PORT: '80'
       - WEBPASSWORD: "{{ pillar['pi-hole']['password'] }}"
     - restart_policy: always
+    - network:
+      - https-portal-network
+        - aliases:
+          - pi-hole
     - binds:
       - {{ pi_hole_dir }}/pihole-FTL.db:/etc/pihole/pihole-FTL.db
       - {{ pi_hole_dir }}/robots.txt:/var/www/html/pihole/robots.txt
@@ -53,3 +57,4 @@ pi-hole:
       - {{ pi_hole_image }}
       - {{ pi_hole_dir }}/pihole-FTL.db
       - {{ pi_hole_dir }}/robots.txt
+      - https-portal-network

--- a/salt/server/pi-hole.sls
+++ b/salt/server/pi-hole.sls
@@ -2,7 +2,6 @@
 {% set virtual_host = pillar['pi-hole']['virtual_host'] %}
 {% set pi_hole_image = 'diginc/pi-hole:latest' %}
 {% set pull_latest = pillar['docker_pull_latest'] %}
-{% set letsencrypt = pillar['letsencrypt'] %}
 {% set pi_hole_dir = '/opt/pi-hole' %}
 
 {{ pi_hole_dir }}:

--- a/salt/server/pi-hole.sls
+++ b/salt/server/pi-hole.sls
@@ -45,9 +45,6 @@ pi-hole:
       - ServerIP: {{ ip_address }}
       - VIRTUAL_HOST: {{ virtual_host }}
       - VIRTUAL_PORT: '80'
-      - LETSENCRYPT_HOST: {{ virtual_host }}
-      - LETSENCRYPT_EMAIL: {{ letsencrypt['email'] }}
-      - LETSENCRYPT_TEST: "{{ letsencrypt['test'] }}"
       - WEBPASSWORD: "{{ pillar['pi-hole']['password'] }}"
     - restart_policy: always
     - binds:

--- a/salt/server/website.sls
+++ b/salt/server/website.sls
@@ -1,22 +1,5 @@
-{% set letsencrypt_dir = '/opt/letsencrypt' %}
 {% set pull_latest = pillar['docker_pull_latest'] %}
-{% set website = pillar['website'] %}
 {% set eligundry_image = 'eligundry/eligundry.com:latest' %}
-{% set nginx_image = 'jwilder/nginx-proxy:alpine' %}
-{% set letsencrypt = pillar['letsencrypt'] %}
-{% set letsencrypt_image = 'jrcs/letsencrypt-nginx-proxy-companion:latest' %}
-
-{{ letsencrypt_dir }}:
-  file.directory:
-    - user: docker
-    - group: docker
-    - dir_mode: 775
-    - file_mode: 660
-    - makedirs: True
-    - recurse:
-      - user
-      - group
-      - mode
 
 {{ eligundry_image }}:
   docker_image.present:
@@ -25,63 +8,6 @@
 eligundry.com:
   docker_container.running:
     - image: {{ eligundry_image }}
-    - environment:
-      - VIRTUAL_HOST: {{ website['virtual_host'] }}
-      - VIRTUAL_PORT: 8080
-      - LETSENCRYPT_HOST: {{ letsencrypt['host'] }}
-      - LETSENCRYPT_EMAIL: {{ letsencrypt['email'] }}
-      - LETSENCRYPT_TEST: "{{ letsencrypt['test'] }}"
-      - ENABLE_IPV6: "true"
     - restart_policy: always
     - require:
-      - nginx-proxy
       - {{ eligundry_image }}
-
-{{ nginx_image }}:
-  docker_image.present:
-    - force: {{ pull_latest }}
-
-nginx-proxy:
-  docker_container.running:
-    - image: {{ nginx_image }}
-    - volumes:
-      - /etc/nginx/conf.d
-      - /etc/nginx/vhost.d
-      - /usr/share/nginx/html
-    - binds:
-      - /var/run/docker.sock:/tmp/docker.sock:ro
-      - {{ letsencrypt_dir }}:/etc/nginx/certs:ro
-    - port_bindings:
-      - "80:80"
-      - "443:443"
-    - restart_policy: always
-    - require:
-      - {{ nginx_image }}
-      - {{ letsencrypt_dir }}
-
-# This is disabled in Vagrant because it will fail to validate certs and make
-# the dev website impossible to reach because certs and will force SSL on the
-# Nginx reverse proxy.
-{% if salt['grains.get']('virtual') != 'VirtualBox' %}
-
-{{ letsencrypt_image }}:
-  docker_image.present:
-    - force: {{ pull_latest }}
-
-letsencrypt:
-  docker_container.running:
-    - image: {{ letsencrypt_image }}
-    - volumes_from:
-      - nginx-proxy
-    - binds:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - {{ letsencrypt_dir }}:/etc/nginx/certs:rw
-    - restart_policy: always
-    - environment:
-      - ACME_TOS_HASH=cc88d8d9517f490191401e7b54e9ffd12a2b9082ec7a1d4cec6101f9f1647e7b
-    - require:
-      - {{ letsencrypt_dir }}
-      - {{ letsencrypt_image }}
-      - nginx-proxy
-
-{% endif %}

--- a/salt/server/website.sls
+++ b/salt/server/website.sls
@@ -9,5 +9,10 @@ eligundry-website:
   docker_container.running:
     - image: {{ eligundry_image }}
     - restart_policy: always
+    - network:
+      - https-portal-network
+        - aliases:
+          - eligundry-website
     - require:
       - {{ eligundry_image }}
+      - https-portal-network

--- a/salt/server/website.sls
+++ b/salt/server/website.sls
@@ -5,7 +5,7 @@
   docker_image.present:
     - force: {{ pull_latest }}
 
-eligundry.com:
+eligundry-website:
   docker_container.running:
     - image: {{ eligundry_image }}
     - restart_policy: always

--- a/salt/server/website.sls
+++ b/salt/server/website.sls
@@ -9,7 +9,7 @@ eligundry-website:
   docker_container.running:
     - image: {{ eligundry_image }}
     - restart_policy: always
-    - network:
+    - networks:
       - https-portal-network:
         - aliases:
           - eligundry-website

--- a/salt/server/website.sls
+++ b/salt/server/website.sls
@@ -10,7 +10,7 @@ eligundry-website:
     - image: {{ eligundry_image }}
     - restart_policy: always
     - network:
-      - https-portal-network
+      - https-portal-network:
         - aliases:
           - eligundry-website
     - require:

--- a/salt/server/znc/init.sls
+++ b/salt/server/znc/init.sls
@@ -20,7 +20,7 @@
     - source: salt://server/znc/znc.conf
     - template: jinja
     - defaults:
-        proxy_ip: {{ salt['cmd.run']("docker inspect --format '{{ .NetworkSettings.IPAddress }}' nginx-proxy") }}
+        proxy_ip: {{ salt['cmd.run']("docker inspect --format '{{ .NetworkSettings.IPAddress }}' https-portal") }}
         password_hash: {{ znc_config['password']['hash'] }}
         password_salt: {{ znc_config['password']['salt'] }}
     - require:


### PR DESCRIPTION
I have been using [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy) to serve all my Docker webapps since I launched my server. Recently, it has become clear that that image will not be able to support newer versions of the Let's Encrypt APIs. Furthermore, I've been running it in a very insecure fashion by having it auto generate configs from other container's environment variables (binding to the Docker socket on anything that is web facing is asking for trouble).

Enter [SteveLTN/https-portal](https://github.com/SteveLTN/https-portal). It works in a similar fashion, doesn't require binding to the Docker socket, has more features, and supports the newest versions of the Let's Encrypt API. This should be a simple swap, but we'll see.

# Update 2018-01-06

Finally got this working. I ran into some roadblocks around how Docker networking works. I use Docker Compose much more often than the regular Docker commands. Docker Compose provides a network per `docker-compose.yml` and with that network, it'll add aliases to it's network that match the `service` keys. So, when I attempted to use my containers by their container names for nginx upstreams, it failed. Near as I can tell, my previous nginx proxy was handling this transparently for me through the Docker socket.