### PR TITLE
Salt API!

### DIFF
--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -3,6 +3,7 @@ include:
   - server.salt-master
   - server.salt-cloud
   - server.salt-master
+  - server.salt-api
   # Swapped to https-portal from the nginx-proxy
   - server.https-portal
   # - server.nginx-proxy

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -1,0 +1,42 @@
+{% set docker_host_image = 'qoomon/docker-host:latest' %}
+{% set pull_latest = pillar['docker_pull_latest'] %}
+
+# This state is to setup the Salt REST API so that I can trigger deploys from
+# GitHub Actions without ssh'ing. The docs suggest to have this protected by SSL 
+# and to generate self signed certificates to make this secure. I don't want to 
+# do self signed certs and I have a reverse proxy that handles LetsEncrypt, so
+# I'm going to route all traffic through that for this. Unfortunately, there 
+# isn't a Docker image for this so I'm going to use docker-host to proxy traffic
+# from the reverse proxy to the API that way.
+
+{% for user in pillar['salt-api']['users'] %}
+docker-user:
+  user.present:
+{% endfor %}
+
+salt-api:
+  pkg.installed
+
+CherryPy:
+  pip.installed
+
+{{ docker_host_image }}:
+  docker_image.present:
+    - force: {{ pull_latest }}
+
+docker-host:
+  docker_container.running:
+    - image: {{ docker_host_image }}
+    - networks:
+      - https-portal-network:
+        - aliases:
+          - docker-host
+    - require:
+      - https-portal-network
+
+salt-api-service:
+  service.running:
+    - name: salt-api
+    - enable: true
+    - watch:
+      - file: /etc/salt/master

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -32,6 +32,7 @@ docker-host:
       - NET_ADMIN
       - NET_RAW
     - networks:
+      - host: {}
       - https-portal-network:
         - aliases:
           - docker-host

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -31,6 +31,9 @@ CherryPy:
 docker-host:
   docker_container.running:
     - image: {{ docker_host_image }}
+    - cap_add:
+      - NET_ADMIN
+      - NET_RAW
     - networks:
       - https-portal-network:
         - aliases:

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -21,9 +21,6 @@ salt-api-{{ user['name'] }}:
 salt-api:
   pkg.installed
 
-CherryPy:
-  pip.installed
-
 {{ docker_host_image }}:
   docker_image.present:
     - force: {{ pull_latest }}

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -10,8 +10,12 @@
 # from the reverse proxy to the API that way.
 
 {% for user in pillar['salt-api']['users'] %}
-docker-user:
+salt-api-{{ user['name'] }}:
   user.present:
+    - name: {{ user['name'] }}
+    - password: {{ user['password'] }}
+    - createhome: false
+    - shell: /usr/sbin/nologin
 {% endfor %}
 
 salt-api:

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -15,7 +15,6 @@ salt-api-{{ user['name'] }}:
     - name: {{ user['name'] }}
     - password: {{ user['password'] }}
     - createhome: false
-    - shell: /usr/sbin/nologin
 {% endfor %}
 
 salt-api:

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -31,7 +31,6 @@ docker-host:
     - cap_add:
       - NET_ADMIN
       - NET_RAW
-    - network_mode: host
     - networks:
       - https-portal-network:
         - aliases:

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -13,7 +13,6 @@
 salt-api-{{ user['name'] }}:
   user.present:
     - name: {{ user['name'] }}
-    - password: {{ user['password'] }}
     - createhome: false
     - shell: /bin/bash
 {% endfor %}

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -31,8 +31,8 @@ docker-host:
     - cap_add:
       - NET_ADMIN
       - NET_RAW
+    - network_mode: host
     - networks:
-      - host
       - https-portal-network:
         - aliases:
           - docker-host

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -32,7 +32,7 @@ docker-host:
       - NET_ADMIN
       - NET_RAW
     - networks:
-      - host: {}
+      - host
       - https-portal-network:
         - aliases:
           - docker-host

--- a/salt/server/salt-api/init.sls
+++ b/salt/server/salt-api/init.sls
@@ -15,6 +15,7 @@ salt-api-{{ user['name'] }}:
     - name: {{ user['name'] }}
     - password: {{ user['password'] }}
     - createhome: false
+    - shell: /bin/bash
 {% endfor %}
 
 salt-api:

--- a/salt/server/salt-master/master.sls
+++ b/salt/server/salt-master/master.sls
@@ -373,7 +373,6 @@ external_auth:
 rest_cherrypy:
   port: 6969
   disable_ssl: true
-  enable_sessions: false
 
 # Time (in seconds) for a newly generated token to live. Default: 12 hours
 #token_expire: 43200

--- a/salt/server/salt-master/master.sls
+++ b/salt/server/salt-master/master.sls
@@ -371,6 +371,7 @@ rest_cherrypy:
   port: 6969
   host: 127.0.0.1
   disable_ssl: true
+  enable_sessions: false
 
 # Time (in seconds) for a newly generated token to live. Default: 12 hours
 #token_expire: 43200

--- a/salt/server/salt-master/master.sls
+++ b/salt/server/salt-master/master.sls
@@ -369,7 +369,6 @@ external_auth:
 # REST API 4 Salt
 rest_cherrypy:
   port: 6969
-  host: 127.0.0.1
   disable_ssl: true
   enable_sessions: false
 

--- a/salt/server/salt-master/master.sls
+++ b/salt/server/salt-master/master.sls
@@ -355,6 +355,9 @@ user: root
 #
 #sudo_acl: False
 
+# Allow Linux users to authenticate with the API via PAM
+auth.pam.service: login
+
 # The external auth system uses the Salt auth modules to authenticate and
 # validate users to access areas of the Salt system.
 external_auth:

--- a/salt/server/salt-master/master.sls
+++ b/salt/server/salt-master/master.sls
@@ -357,10 +357,14 @@ user: root
 
 # The external auth system uses the Salt auth modules to authenticate and
 # validate users to access areas of the Salt system.
-#external_auth:
-#  pam:
-#    fred:
-#      - test.*
+external_auth:
+  pam:
+    {{ pillar['user']['name'] }}:
+      - '.*'
+  {% for user in pillar['salt-api']['users'] -%}
+    {{ user['name'] }}:
+      - '.*'
+  {% endfor %}
 #
 # Time (in seconds) for a newly generated token to live. Default: 12 hours
 #token_expire: 43200

--- a/salt/server/salt-master/master.sls
+++ b/salt/server/salt-master/master.sls
@@ -361,11 +361,17 @@ external_auth:
   pam:
     {{ pillar['user']['name'] }}:
       - '.*'
-  {% for user in pillar['salt-api']['users'] -%}
+  {% for user in pillar['salt-api']['users'] %}
     {{ user['name'] }}:
       - '.*'
   {% endfor %}
-#
+
+# REST API 4 Salt
+rest_cherrypy:
+  port: 6969
+  host: 127.0.0.1
+  disable_ssl: true
+
 # Time (in seconds) for a newly generated token to live. Default: 12 hours
 #token_expire: 43200
 #

--- a/salt/server/website.sls
+++ b/salt/server/website.sls
@@ -1,3 +1,6 @@
+include:
+  - server.https-portal
+
 {% set pull_latest = pillar['docker_pull_latest'] %}
 {% set eligundry_image = 'eligundry/eligundry.com:latest' %}
 {% set beta_image = 'eligundry/website.eligundry.com:latest' %}


### PR DESCRIPTION
During my refactor of my personal site, I setup Github Actions to build the Docker containers that run my site. These work great, but I have been deploying them manually by `ssh`ing on to my DigitalOcean droplet and applying the Salt states. This is boring, so I decided to automate it.

I did some quick Googling and discovered that Salt has a [REST API](https://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html). This PR implements that API and sets up users to use this. I will eventually wire up the Github Action deploying my site to use this API to trigger a Docker pull and whatnot.

This also opens me up to using Salt with Github Actions is some really fun ways! I'm thinking that I could trigger a highstate on all pushes to master on all machines connected to the Salt Master! Babysteps, just gotta get the new site out before I do more interesting things!